### PR TITLE
Local Session Storage & Mute

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Pymodoro brings the famous Pomodoro Technique to your terminal with a gorgeous i
 
 - 🎨 **Beautiful TUI** - Rich terminal interface with session-aware colors
 - 🍅 **Visual Progress** - Chunky progress bars and ASCII tomato art
-- 🔊 **Audio Notifications** - Sound alerts for session transitions
+- 🔊 **Audio Notifications** - Sound alerts for session transitions (with mute option)
 - ⏸️ **Pause/Resume** - Full control over your timer
 - 🔄 **Session Reset** - Restart current session from the beginning when distracted
 - 🛡️ **Smart Confirmations** - Prevent accidental skips, resets, and quits
@@ -96,7 +96,9 @@ pymodoro --help
 | `SPACE` | Pause/Resume current session |
 | `N` | Skip to next session (with confirmation) |
 | `R` | Reset current session to beginning (with confirmation) |
+| `M` | Toggle mute/unmute sounds |
 | `Q` | Quit application (with confirmation) |
+| `H` | Show help screen |
 
 ## 📖 How It Works
 
@@ -142,6 +144,7 @@ Timer Options:
   -l, --long MINUTES     Long break duration (default: 15)
   -n, --notify MINUTES   Warning sound N minutes before session ends (default: 1)
   -f, --frequency COUNT  Work sessions before long break (default: 4)
+  -m, --mute             Mute all sound notifications
 
 Session Management:
   --reset_log           Reset today's session log to empty and exit
@@ -166,6 +169,10 @@ uv run pymodoro --work 45 --short 15 --long 30
 
 # Configure warnings and long break frequency
 pymodoro -n 2 -f 3    # 2-minute warning, long break every 3 sessions
+
+# Mute sounds for quiet environments
+pymodoro --mute       # Start with all sounds disabled
+pymodoro -m -w 45     # 45-minute sessions with sounds muted
 
 # Session log management
 pymodoro --reset_log  # Clear today's session history

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Pymodoro brings the famous Pomodoro Technique to your terminal with a gorgeous i
 - ⏸️ **Pause/Resume** - Full control over your timer
 - 🔄 **Session Reset** - Restart current session from the beginning when distracted
 - 🛡️ **Smart Confirmations** - Prevent accidental skips, resets, and quits
-- 📊 **Pomodoro Tracking** - Count completed work sessions
+- 📊 **Session Logging** - Persistent daily logs with timestamps and notes
 - 🎯 **Customizable Sessions** - Configure work, short break, and long break durations
 - ⌨️ **Keyboard Controls** - Intuitive single-key commands
+- 📝 **Log Management** - Reset logs or edit with your preferred editor
 
 ## 🚀 Quick Start
 
@@ -135,10 +136,18 @@ The interface changes colors based on your current session:
 ```bash
 pymodoro [OPTIONS]
 
-Options:
+Timer Options:
   -w, --work MINUTES     Work session duration (default: 25)
   -s, --short MINUTES    Short break duration (default: 5)
   -l, --long MINUTES     Long break duration (default: 15)
+  -n, --notify MINUTES   Warning sound N minutes before session ends (default: 1)
+  -f, --frequency COUNT  Work sessions before long break (default: 4)
+
+Session Management:
+  --reset_log           Reset today's session log to empty and exit
+  --open_log            Open today's session log in default editor and exit
+
+General:
   -h, --help            Show help message
   --version             Show version information
 ```
@@ -154,6 +163,13 @@ pymodoro -w 15 -s 5
 
 # Custom everything (using uv run from source)
 uv run pymodoro --work 45 --short 15 --long 30
+
+# Configure warnings and long break frequency
+pymodoro -n 2 -f 3    # 2-minute warning, long break every 3 sessions
+
+# Session log management
+pymodoro --reset_log  # Clear today's session history
+pymodoro --open_log   # Edit today's session log with notes
 ```
 
 ## 🎯 The Pomodoro Technique

--- a/docs_ai/feature_save_session.md
+++ b/docs_ai/feature_save_session.md
@@ -1,0 +1,127 @@
+# Feature: Persistent Daily Session Logging
+
+## 📜 Overview & Goal
+
+The primary goal of this feature is to make the Pymodoro timer stateful by persisting session data. Each completed Pomodoro session will be saved to a daily log file in YAML format. This allows for session history, tracking productivity over time, and resuming session counts across application restarts.
+
+The design emphasizes data integrity, cross-platform compatibility, and human-readability of the log files.
+
+## 🎯 Key Priorities
+
+1.  **Data Integrity**: Session data is valuable. We must prevent data loss, even if the application crashes during a write operation. Atomic writes are non-negotiable.
+2.  **Robustness**: The application must gracefully handle scenarios like missing log files, corrupted data, and file permission issues.
+3.  **Cross-Platform Compatibility**: The feature must work seamlessly on Linux, macOS, and Windows. File paths will be resolved using the XDG Base Directory Specification.
+4.  **Simplicity & Maintainability**: The implementation should be straightforward, leveraging Pydantic for data validation and standard libraries for file operations to ensure the code is easy to understand and maintain.
+
+## 📂 File Storage and Management
+
+Session logs will be stored in a dedicated, platform-appropriate directory.
+
+-   **Path Strategy**: We will adhere to the XDG Base Directory Specification.
+    -   The base directory will be resolved from the `$XDG_STATE_HOME` environment variable.
+    -   **Fallback on UNIX/macOS**: `~/.local/state`
+    -   **Fallback on Windows**: `%APPDATA%` (e.g., `C:\Users\<user>\AppData\Roaming`)
+-   **Directory Structure**: Logs will be stored under `<base_directory>/pymodoro/logs/`.
+-   **File Naming**: Each log file will be named after the date of the session in `YYYY-MM-DD.yaml` format.
+-   **Automation**: The application must automatically create the necessary directories on its first run.
+
+## 📝 Data Schema
+
+We will use Pydantic to define a strict schema for our session data, which ensures type safety and validation at runtime. The data will be serialized to a human-readable YAML format.
+
+### Pydantic Models
+
+```python
+# src/pymodoro/session_model.py
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+class Session(BaseModel):
+    """Represents a single Pomodoro work session."""
+    start: datetime
+    duration_minutes: int = Field(25, gt=0)
+    notes: Optional[str] = None
+
+class DayLog(BaseModel):
+    """Represents the log for a single day, containing all sessions."""
+    log_date: date
+    sessions: List[Session] = []
+
+    @property
+    def session_count(self) -> int:
+        """Returns the number of completed sessions for the day."""
+        return len(self.sessions)
+```
+
+### Example YAML File (`2024-08-07.yaml`)
+
+```yaml
+log_date: 2024-08-07
+sessions:
+  - start: '2024-08-07T09:05:15.123456'
+    duration_minutes: 25
+    notes: 'Drafted initial feature specification.'
+  - start: '2024-08-07T09:35:45.567890'
+    duration_minutes: 25
+    notes: 'Implemented Pydantic models and file path logic.'
+```
+
+## 🔄 Core Workflow
+
+### A. Application Start-Up
+
+1.  Determine the path for today's log file (e.g., `.../pymodoro/logs/2024-08-07.yaml`).
+2.  If the file exists, load and parse it using `yaml.safe_load()`.
+3.  Validate the loaded data against the `DayLog` Pydantic model.
+4.  If the file does not exist or is empty, initialize a new `DayLog` object for the current date.
+5.  The `DayLog.session_count` property will provide the session count for the day so far.
+
+### B. Session Completion
+
+1.  When a Pomodoro timer finishes a session, record the `start` datetime and `duration`.
+2.  (Optional) Prompt the user to enter brief notes for the session (manually in the YAML file)
+3.  Create a new `Session` object with this data.
+4.  Append the new `Session` to the `sessions` list of the current `DayLog` object.
+5.  Save the entire `DayLog` object back to the YAML file using an atomic write operation to prevent data corruption.
+
+## ⚠️ Edge Cases and Recovery
+
+-   **Corrupt YAML File**: If `yaml.safe_load()` fails or Pydantic validation throws an error, the corrupt file should be backed up (e.g., renamed to `YYYY-MM-DD.yaml.corrupt`) and a new, empty log for the day should be created. A warning should be logged.
+-   **Atomic Write Failure**: The atomic write process involves writing to a temporary file (`.tmp`) and then renaming it. If the app crashes, a `.tmp` file might be left behind. On startup, if a `.tmp` file exists, it can be considered more recent and used to recover data, but the primary log file should not be overwritten without a clear recovery strategy. For simplicity, we can start by just logging a warning if a stale `.tmp` file is found.
+-   **Cross-Midnight Sessions**: A session will be logged to the date on which it *started*. This is the simplest approach and avoids complexity.
+-   **Permissions**: The application should handle `PermissionError` when creating directories or writing files and log a clear error message to the user.
+
+## ✅ Implementation Tasks
+
+- [x] **1. Setup & Dependencies**:
+    - [x] Create a new directory `docs_ai`.
+    - [x] Create this file `docs_ai/feature_save_session.md`.
+    - [x] Add `PyYAML` and `pydantic` to the project dependencies.
+
+- [x] **2. Data Models**:
+    - [x] Create a new file `src/pymodoro/session_model.py`.
+    - [x] Implement the `Session` and `DayLog` Pydantic models as defined in the schema section.
+
+- [x] **3. Storage Utility**:
+    - [x] Create a new file `src/pymodoro/storage.py`.
+    - [x] Implement a function `get_log_file_path() -> Path` that resolves the correct path for the current day's log file according to the XDG specification. This function should also ensure the containing directories exist, creating them if necessary (`mkdir(parents=True, exist_ok=True)`).
+
+- [x] **4. Core Logic**:
+    - [x] In `src/pymodoro/storage.py`, implement `load_or_initialize_day_log() -> DayLog`. This function will use `get_log_file_path()` and handle loading, validation, and initialization of a new log if one doesn't exist or is corrupt.
+    - [x] In `src/pymodoro/storage.py`, implement `save_day_log(day_log: DayLog)`. This function must perform an atomic write to the log file.
+
+- [x] **5. Application Integration**:
+    - [x] In the main application logic, call `load_or_initialize_day_log()` on startup to load the session data.
+    - [x] Update the UI/display to reflect the session count from the loaded `DayLog` object.
+    - [x] When a session completes, create and append a new `Session` object to the `DayLog`.
+    - [x] Call `save_day_log()` to persist the updated `DayLog`.
+
+- [ ] **6. User Interaction**:
+    - [ ] After a session completes, add a simple mechanism to prompt the user for notes. An empty note is acceptable.
+
+- [ ] **7. Testing**:
+    - [ ] Write unit tests for `get_log_file_path()` to verify correct path resolution on different platforms (can be mocked).
+    - [ ] Write tests for `load_or_initialize_day_log` and `save_day_log` to cover success, file-not-found, and corruption scenarios. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "playsound>=1.3.0",
+    "pyaml>=25.5.0",
+    "pydantic>=2.11.5",
     "rich>=14.0.0",
 ]
 

--- a/src/pymodoro/interface.py
+++ b/src/pymodoro/interface.py
@@ -18,12 +18,14 @@ class PomodoroUI:
         total_time = self.timer.settings[session_type]
         pomodoros_completed = self.timer.pomodoros_completed
         is_paused = not self.timer.is_running
+        is_muted = self.timer.is_muted
         
         # Create cache key based on meaningful state
         cache_key = (
             session_type,
             pomodoros_completed,
             is_paused,
+            is_muted,
             int(time_left),  # Round to seconds
             confirmation_type
         )
@@ -39,7 +41,8 @@ class PomodoroUI:
                 session_type=session_type,
                 time_left=time_left,
                 pomodoros_completed=pomodoros_completed,
-                is_paused=is_paused
+                is_paused=is_paused,
+                is_muted=is_muted
             )
         else:
             screen = self.screen_manager.get_screen(
@@ -48,7 +51,8 @@ class PomodoroUI:
                 time_left=time_left,
                 total_time=total_time,
                 pomodoros_completed=pomodoros_completed,
-                is_paused=is_paused
+                is_paused=is_paused,
+                is_muted=is_muted
             )
         
         # Cache the result

--- a/src/pymodoro/session_model.py
+++ b/src/pymodoro/session_model.py
@@ -1,0 +1,24 @@
+# src/pymodoro/session_model.py
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Session(BaseModel):
+    """Represents a single Pomodoro work session."""
+    start: datetime
+    duration_minutes: int = Field(25, gt=0)
+    notes: Optional[str] = None
+
+
+class DayLog(BaseModel):
+    """Represents the log for a single day, containing all sessions."""
+    log_date: date
+    sessions: List[Session] = Field(default_factory=list)
+
+    @property
+    def session_count(self) -> int:
+        """Returns the number of completed sessions for the day."""
+        return len(self.sessions)

--- a/src/pymodoro/sound.py
+++ b/src/pymodoro/sound.py
@@ -185,16 +185,22 @@ def play_notification_sound(sound_type: str = "default") -> bool:
     return True
 
 
-def play_work_end() -> bool:
+def play_work_end(muted: bool = False) -> bool:
     """Play a sound to signify the end of a work session."""
+    if muted:
+        return True
     return play_notification_sound("work_end")
 
 
-def play_break_end() -> bool:
+def play_break_end(muted: bool = False) -> bool:
     """Play a sound to signify the end of a break session."""
+    if muted:
+        return True
     return play_notification_sound("break_end")
 
 
-def play_warning() -> bool:
+def play_warning(muted: bool = False) -> bool:
     """Play a warning sound to notify user of approaching session end."""
+    if muted:
+        return True
     return play_notification_sound("default")

--- a/src/pymodoro/storage.py
+++ b/src/pymodoro/storage.py
@@ -1,0 +1,136 @@
+# src/pymodoro/storage.py
+
+import os
+import platform
+import tempfile
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import ValidationError
+
+from pymodoro.session_model import DayLog, Session
+
+
+def get_log_file_path() -> Path:
+    """Get the path for today's log file according to XDG spec."""
+    system = platform.system()
+    
+    if system == "Windows":
+        base_dir = Path(os.environ.get("APPDATA", "~")).expanduser()
+    else:
+        # Unix/Linux/macOS
+        base_dir = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    
+    log_dir = base_dir / "pymodoro" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    
+    today = date.today()
+    return log_dir / f"{today.isoformat()}.yaml"
+
+
+def load_or_initialize_day_log() -> DayLog:
+    """Load today's log file or initialize a new one."""
+    log_file = get_log_file_path()
+    today = date.today()
+    
+    if not log_file.exists():
+        return DayLog(log_date=today)
+    
+    try:
+        with open(log_file, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f) or {}
+        
+        return DayLog(**data)
+    
+    except (yaml.YAMLError, ValidationError, OSError) as e:
+        # Back up corrupt file and start fresh
+        backup_path = log_file.with_suffix('.yaml.corrupt')
+        try:
+            log_file.rename(backup_path)
+        except OSError:
+            pass
+        
+        return DayLog(log_date=today)
+
+
+def save_day_log(day_log: DayLog) -> None:
+    """Save the day log using atomic write."""
+    log_file = get_log_file_path()
+    
+    # Prepare data for YAML serialization
+    data = day_log.model_dump(mode='python')
+    
+    # Convert datetime objects to human-readable ISO format strings
+    for session in data['sessions']:
+        if 'start' in session:
+            # Format as YYYY-MM-DD HH:MM:SS for human readability while maintaining ISO compliance
+            session['start'] = session['start'].strftime('%Y-%m-%d %H:%M:%S')
+    
+    # Atomic write using temporary file
+    with tempfile.NamedTemporaryFile(
+        mode='w',
+        encoding='utf-8',
+        dir=log_file.parent,
+        delete=False,
+        suffix='.tmp'
+    ) as tmp_file:
+        yaml.safe_dump(data, tmp_file, default_flow_style=False)
+        tmp_path = Path(tmp_file.name)
+    
+    try:
+        tmp_path.replace(log_file)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def add_session(duration_minutes: int = 25, notes: Optional[str] = None) -> None:
+    """Add a new session to today's log."""
+    from datetime import datetime
+    
+    day_log = load_or_initialize_day_log()
+    session = Session(
+        start=datetime.now(),
+        duration_minutes=duration_minutes,
+        notes=notes
+    )
+    day_log.sessions.append(session)
+    save_day_log(day_log)
+
+
+def reset_today_log() -> None:
+    """Reset today's log to empty."""
+    from datetime import date
+    
+    day_log = DayLog(log_date=date.today())
+    save_day_log(day_log)
+
+
+def open_log_in_editor() -> None:
+    """Open today's log file in the system's default editor."""
+    log_file = get_log_file_path()
+    
+    # Ensure log file exists
+    if not log_file.exists():
+        day_log = load_or_initialize_day_log()
+        save_day_log(day_log)
+    
+    # Use Unix editor precedence: $VISUAL -> $EDITOR -> vim
+    system = platform.system()
+    try:
+        if system == "Windows":
+            subprocess.run(["start", str(log_file)], shell=True, check=True)
+        else:  # macOS, Linux, Unix
+            # Follow Unix convention: VISUAL > EDITOR > vim
+            editor = (os.environ.get("VISUAL") or 
+                     os.environ.get("EDITOR") or 
+                     "vim")
+            subprocess.run([editor, str(log_file)], check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Fallback: print file path for manual opening
+        print(f"Could not open editor. Log file location: {log_file}")
+        sys.exit(1)

--- a/src/pymodoro/timer.py
+++ b/src/pymodoro/timer.py
@@ -8,7 +8,7 @@ class SessionType(Enum):
     LONG_BREAK = auto()
 
 class PomodoroTimer:
-    def __init__(self, work_mins=25, short_break_mins=5, long_break_mins=15, warning_mins=1, long_break_frequency=4):
+    def __init__(self, work_mins=25, short_break_mins=5, long_break_mins=15, warning_mins=1, long_break_frequency=4, mute=False):
         self.settings = {
             SessionType.WORK: work_mins * 60,
             SessionType.SHORT_BREAK: short_break_mins * 60,
@@ -23,6 +23,7 @@ class PomodoroTimer:
         self.warning_minutes = warning_mins
         self.long_break_frequency = long_break_frequency  # How many work sessions before long break
         self._warning_played = False  # Track if warning has been played for current session
+        self.is_muted = mute  # Mute state for sound notifications
 
     def start(self):
         if not self.is_running:
@@ -47,6 +48,10 @@ class PomodoroTimer:
             self.pause()
         else:
             self.resume()
+    
+    def toggle_mute(self):
+        """Toggle mute state for sound notifications."""
+        self.is_muted = not self.is_muted
     
     def reset(self):
         """Reset the current session timer to its full duration."""

--- a/src/pymodoro/ui/components.py
+++ b/src/pymodoro/ui/components.py
@@ -57,7 +57,7 @@ class ProgressBar:
 class Header:
     """Renders session title, pomodoro number, and pause status."""
     
-    def render(self, theme: SessionTheme, pomodoros_completed: int, is_paused: bool, display_color: str) -> Text:
+    def render(self, theme: SessionTheme, pomodoros_completed: int, is_paused: bool, display_color: str, is_muted: bool = False) -> Text:
         """Render header text component."""
         try:
             header = Text(no_wrap=True, justify="center")
@@ -73,10 +73,20 @@ class Header:
                 header.append(" ", style=f"bold {display_color}")
                 header.append(theme.short_name, style=f"bold {display_color}")
             
+            # Add status indicators
+            status_added = False
+            
             # Add paused indicator if needed
             if is_paused:
                 header.append(" | ", style=f"bold {display_color}")
                 header.append("PAUSED", style="bold yellow")
+                status_added = True
+            
+            # Add muted indicator if needed
+            if is_muted:
+                separator = " | " if status_added else " | "
+                header.append(separator, style=f"bold {display_color}")
+                header.append("🔇 MUTED", style="bold dim")
             
             return header
         except Exception:
@@ -109,6 +119,7 @@ class Dialog:
             help_table.add_column("Action", style="white")
             
             help_table.add_row("SPACE", "Pause/Resume the current session")
+            help_table.add_row("m", "Mute/Unmute sounds")
             help_table.add_row("n", "Skip to next session (with confirmation)")
             help_table.add_row("r", "Reset current session (with confirmation)")
             help_table.add_row("q", "Quit application (with confirmation)")
@@ -156,7 +167,7 @@ class Dialog:
             fallback_content = Text("Help screen unavailable", justify="center", style="white")
             return Panel(fallback_content, border_style="white", title="Help")
     
-    def render_confirmation(self, confirmation_type: str, theme: SessionTheme, time_left: float, pomodoros_completed: int, display_color: str) -> Panel:
+    def render_confirmation(self, confirmation_type: str, theme: SessionTheme, time_left: float, pomodoros_completed: int, display_color: str, is_muted: bool = False) -> Panel:
         """Render confirmation dialog."""
         try:
             # Create confirmation content

--- a/src/pymodoro/ui/screens.py
+++ b/src/pymodoro/ui/screens.py
@@ -25,14 +25,14 @@ class MainScreen(Screen):
         self.art_display = ArtDisplay()
     
     def render(self, session_type: SessionType, time_left: float, total_time: float, 
-              pomodoros_completed: int, is_paused: bool) -> Any:
+              pomodoros_completed: int, is_paused: bool, is_muted: bool = False) -> Any:
         """Render the main timer screen."""
         # Get theme and display color
         theme = self.theme_manager.get_theme(session_type, is_paused)
         display_color = self.theme_manager.get_display_color(session_type, is_paused)
         
         # Create all components
-        header = self.header.render(theme, pomodoros_completed, is_paused, display_color)
+        header = self.header.render(theme, pomodoros_completed, is_paused, display_color, is_muted)
         art = self.art_display.render(theme.art)
         timer = self.timer_display.render(time_left, display_color)
         
@@ -64,7 +64,7 @@ class HelpScreen(Screen):
         self.theme_manager = theme_manager
         self.dialog = Dialog(theme_manager.dimensions)
     
-    def render(self, session_type: SessionType, time_left: float, pomodoros_completed: int, is_paused: bool) -> Any:
+    def render(self, session_type: SessionType, time_left: float, pomodoros_completed: int, is_paused: bool, is_muted: bool = False) -> Any:
         """Render the help screen."""
         theme = self.theme_manager.get_theme(session_type, is_paused)
         display_color = self.theme_manager.get_display_color(session_type, is_paused)
@@ -80,13 +80,13 @@ class ConfirmationScreen(Screen):
         self.dialog = Dialog(theme_manager.dimensions)
     
     def render(self, confirmation_type: str, session_type: SessionType, time_left: float, 
-              pomodoros_completed: int, is_paused: bool) -> Any:
+              pomodoros_completed: int, is_paused: bool, is_muted: bool = False) -> Any:
         """Render a confirmation dialog."""
         theme = self.theme_manager.get_theme(session_type, is_paused)
         display_color = self.theme_manager.get_display_color(session_type, is_paused)
         
         confirmation_panel = self.dialog.render_confirmation(
-            confirmation_type, theme, time_left, pomodoros_completed, display_color
+            confirmation_type, theme, time_left, pomodoros_completed, display_color, is_muted
         )
         return Alignment.center_vertical_and_horizontal(confirmation_panel)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -29,6 +38,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/8c/c9f46b4b194126c4abb12e96321a6bea5c8dcc5c0e4d97622c14dfabe299/playsound-1.3.0.tar.gz", hash = "sha256:cc6ed11d773034b0ef624e6bb4bf50f4b76b8414a59ce6d38afb89b423297ced", size = 7650 }
 
 [[package]]
+name = "pyaml"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/40/94f10f32ab952c5cca713d9ac9d8b2fdc37392d90eea403823eeac674c24/pyaml-25.5.0.tar.gz", hash = "sha256:5799560c7b1c9daf35a7a4535f53e2c30323f74cbd7cb4f2e715b16dd681a58a", size = 29812 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/7d/1b5061beff826f902285827261485a058b943332eba8a5532a0164735205/pyaml-25.5.0-py3-none-any.whl", hash = "sha256:b9e0c4e58a5e8003f8f18e802db49fd0563ada587209b13e429bdcbefa87d035", size = 26422 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.11.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/69/831ed22b38ff9b4b64b66569f0e5b7b97cf3638346eb95a2147fdb49ad5f/pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7", size = 444229 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688 },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808 },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580 },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859 },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810 },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498 },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611 },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924 },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196 },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389 },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223 },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473 },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269 },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921 },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -43,13 +107,34 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "playsound" },
+    { name = "pyaml" },
+    { name = "pydantic" },
     { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "playsound", specifier = ">=1.3.0" },
+    { name = "pyaml", specifier = ">=25.5.0" },
+    { name = "pydantic", specifier = ">=2.11.5" },
     { name = "rich", specifier = ">=14.0.0" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]
@@ -63,4 +148,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552 },
 ]


### PR DESCRIPTION
The pymodoro timer will now store it's session in a YAML file locally.
It will read this file and increment the session accordingly, so you can stop the timer during the day and it will pick up where you left off.
We added the ability to reset this local storage too, and there is a section where you can add notes.
Finally we added the ability to mute the timer, from the CLI or the keyboad.